### PR TITLE
Update README about OpenAI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Chat GipiTTY
 [![crates.io](https://img.shields.io/crates/v/cgip.svg)](https://crates.io/crates/cgip)
 
-Chat Gipitty (Chat Get Information, Print Information TTY) is a command line client designed for OpenAI-compatible APIs. It allows you to chat with
-language models in a terminal and even pipe output into it. While optimized for OpenAI's ChatGPT (with GPT-4 as the default model), 
-it works seamlessly with any OpenAI Chat Completions API-compatible provider, including:
+Chat Gipitty (Chat Get Information, Print Information TTY) is a command line client primarily intended for the **official OpenAI Chat Completions API**. It allows you to chat with
+language models in a terminal and even pipe output into it. While optimized for OpenAI's ChatGPT (with GPT-4 as the default model), it can also work with other
+providers that expose OpenAI-compatible endpoints, including:
 
 - **OpenAI** (ChatGPT, GPT-4, GPT-3.5, etc.)
 - **Local models** via [Ollama](https://ollama.com)
@@ -11,6 +11,8 @@ it works seamlessly with any OpenAI Chat Completions API-compatible provider, in
 - **Mistral AI** (via OpenAI-compatible endpoints)
 - **Anthropic Claude** (via OpenAI-compatible endpoints)
 - **Any other provider** implementing the OpenAI Chat Completions API standard
+
+Custom `OPENAI_BASE_URL` values can point to these or other OpenAI-compatible endpoints, but such providers might not implement the complete API and compatibility cannot be guaranteed.
 
 ![logo](./docs/logo-256.png)
 


### PR DESCRIPTION
## Summary
- clarify that Chat GipiTTY is primarily meant for the official OpenAI Chat Completions API
- keep the list of OpenAI-compatible providers but mention that custom `OPENAI_BASE_URL` values may not fully work

## Testing
- `cargo build --quiet`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68525e639a8883319d40bf7fa6f95928