### PR TITLE
Improve agent subcommand prompt

### DIFF
--- a/docs/AGENT_SUBCOMMAND.md
+++ b/docs/AGENT_SUBCOMMAND.md
@@ -32,3 +32,6 @@ cgip agent . "list the current directory"
 ```
 
 This will let the model issue an `execute` call with `ls` and return the result.
+When the model needs additional information to answer your instruction, it will
+automatically run commands using `execute` and use the output to craft the final
+response.

--- a/src/sub/agent.rs
+++ b/src/sub/agent.rs
@@ -27,6 +27,11 @@ pub fn run(args: &AgentSubCommand, client: &mut GptClient) {
         std::process::exit(1);
     }
 
+    let system_message = "You can run shell commands using the `execute` tool.\
+ Use it whenever running a command will help you complete the user's instruction.\
+ Once you have the information you need, return a final answer.";
+    client.add_message(Role::System, system_message.to_string());
+
     if let Some(files) = &args.input {
         for file in files {
             let content = get_file_contents_from_path(file.to_string());


### PR DESCRIPTION
## Summary
- instruct the agent subcommand to use the `execute` tool
- document that the agent will automatically run commands as needed

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6854967907708331a431cbfb6e19b74c