### PR TITLE
Add install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ You can fetch the latest pre-built binary using the install script:
 ```sh
 curl -fsSL https://raw.githubusercontent.com/divanvisagie/chat-gipity/main/scripts/install.sh | sh
 ```
-The script installs to `/usr/local` when writable and falls back to `~/.local` if not. Use `--update` to replace an existing installation.
+The script installs to `/usr/local` when writable and falls back to `~/.local` if not.
 
 
 ## Set up API Key

--- a/README.md
+++ b/README.md
@@ -183,6 +183,14 @@ Download this repository and then install the `cgip` command using:
 sudo make install
 ```
 
+#### Install from GitHub Releases
+You can fetch the latest pre-built binary using the install script:
+```sh
+curl -fsSL https://raw.githubusercontent.com/divanvisagie/chat-gipity/main/scripts/install.sh | sudo sh
+```
+Use `--update` to replace an existing installation.
+
+
 ## Set up API Key
 Next, set up your OpenAI key by exporting it as `OPENAI_API_KEY`:
 ```sh

--- a/README.md
+++ b/README.md
@@ -186,9 +186,9 @@ sudo make install
 #### Install from GitHub Releases
 You can fetch the latest pre-built binary using the install script:
 ```sh
-curl -fsSL https://raw.githubusercontent.com/divanvisagie/chat-gipity/main/scripts/install.sh | sudo sh
+curl -fsSL https://raw.githubusercontent.com/divanvisagie/chat-gipity/main/scripts/install.sh | sh
 ```
-Use `--update` to replace an existing installation.
+The script installs to `/usr/local` when writable and falls back to `~/.local` if not. Use `--update` to replace an existing installation.
 
 
 ## Set up API Key

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -37,7 +37,7 @@ case "$ARCH" in
     ARCH="aarch64"
     ;;
   *)
-    echo "Unsupported architecture: $ARCH" >&2
+    echo "Unsupported architecture: $ARCH. Supported architectures are: x86_64, aarch64." >&2
     exit 1
     ;;
 esac

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,10 +1,6 @@
 #!/bin/sh
 set -e
 
-UPDATE=0
-if [ "$1" = "--update" ]; then
-  UPDATE=1
-fi
 
 PREFIX="/usr/local"
 BINARY_PATH="$PREFIX/bin/cgip"
@@ -21,11 +17,6 @@ if ! mkdir -p "$PREFIX/bin" "$MAN_DIR" 2>/dev/null; then
   mkdir -p "$PREFIX/bin" "$MAN_DIR"
 fi
 
-if [ -f "$BINARY_PATH" ] && [ "$UPDATE" -eq 0 ]; then
-  echo "cgip already installed at $BINARY_PATH"
-  echo "Use --update to replace the existing installation." >&2
-  exit 0
-fi
 
 PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,9 +6,20 @@ if [ "$1" = "--update" ]; then
   UPDATE=1
 fi
 
-BINARY_PATH="/usr/local/bin/cgip"
-MAN_DIR="/usr/local/share/man/man1"
+PREFIX="/usr/local"
+BINARY_PATH="$PREFIX/bin/cgip"
+MAN_DIR="$PREFIX/share/man/man1"
 MAN_PATH="$MAN_DIR/cgip.1"
+
+# Fallback to user directory if /usr/local is not writable
+if ! mkdir -p "$PREFIX/bin" "$MAN_DIR" 2>/dev/null; then
+  PREFIX="$HOME/.local"
+  BINARY_PATH="$PREFIX/bin/cgip"
+  MAN_DIR="$PREFIX/share/man/man1"
+  MAN_PATH="$MAN_DIR/cgip.1"
+  echo "Installing to $PREFIX (no write access to /usr/local)"
+  mkdir -p "$PREFIX/bin" "$MAN_DIR"
+fi
 
 if [ -f "$BINARY_PATH" ] && [ "$UPDATE" -eq 0 ]; then
   echo "cgip already installed at $BINARY_PATH"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+set -e
+
+UPDATE=0
+if [ "$1" = "--update" ]; then
+  UPDATE=1
+fi
+
+BINARY_PATH="/usr/local/bin/cgip"
+MAN_DIR="/usr/local/share/man/man1"
+MAN_PATH="$MAN_DIR/cgip.1"
+
+if [ -f "$BINARY_PATH" ] && [ "$UPDATE" -eq 0 ]; then
+  echo "cgip already installed at $BINARY_PATH"
+  echo "Use --update to replace the existing installation." >&2
+  exit 0
+fi
+
+PLATFORM=$(uname -s | tr '[:upper:]' '[:lower:]')
+ARCH=$(uname -m)
+case "$ARCH" in
+  x86_64|amd64)
+    ARCH="x86_64"
+    ;;
+  arm64|aarch64)
+    ARCH="aarch64"
+    ;;
+  *)
+    echo "Unsupported architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+ASSET="cgip-${PLATFORM}-${ARCH}.tar.gz"
+URL="https://github.com/divanvisagie/chat-gipity/releases/latest/download/${ASSET}"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "Downloading $ASSET from $URL" 
+if ! curl -fL "$URL" -o "$TMP_DIR/$ASSET"; then
+  echo "Failed to download release asset" >&2
+  exit 1
+fi
+
+tar -xzf "$TMP_DIR/$ASSET" -C "$TMP_DIR"
+
+install -d "$MAN_DIR"
+install -m 755 "$TMP_DIR/cgip" "$BINARY_PATH"
+install -m 644 "$TMP_DIR/cgip.1" "$MAN_PATH"
+
+echo "cgip installed to $BINARY_PATH"


### PR DESCRIPTION
## Summary
- add `scripts/install.sh` to fetch latest release tarball
- update README with install script instructions
- make install script POSIX compatible

## Testing
- `shellcheck scripts/install.sh`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68549320847c8331abea596b360d31eb