### PR TITLE
Fetch model list from API

### DIFF
--- a/src/chat.rs
+++ b/src/chat.rs
@@ -20,7 +20,7 @@ pub fn run(args: &Args, client: &mut GptClient) {
 
     // List available models
     if args.list_models {
-        let models = vec!["gpt-4o", "gpt-4.1", "o4-mini", "o3-mini", "o1"];
+        let models = client.list_models();
         for model in models {
             println!("{}", model);
         }


### PR DESCRIPTION
## Summary
- support listing available models via the OpenAI API
- add URL helper and tests for models endpoint

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6855d99b28708331a8b15788852221b8